### PR TITLE
User Array.from() to support forEach on a nodeList in older browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,14 +79,18 @@ class CodeBlock extends React.Component {
 
   highlightCode() {
     let nodes = this.node.querySelectorAll("pre code");
-    nodes.forEach(node => {
+    // Use Array.from(nodeList) to support forEach on older
+    // browsers.
+    Array.from(nodes).forEach(node => {
       hljs.highlightBlock(node);
     });
   }
 
   codeToClipboard() {
     let nodes = this.node.querySelectorAll("pre");
-    nodes.forEach(node => {
+    // Use Array.from(nodeList) to support forEach on older
+    // browsers.
+    Array.from(nodes).forEach(node => {
       const newNode = this.createNewNode(node);
       const parent = node.parentNode;
       parent.replaceChild(newNode, node);


### PR DESCRIPTION
Older browsers (eg. Chrome 49 from Mar 2016) will error on nodeList.forEach with:

`TypeError: this.node.querySelectorAll(...).forEach is not a function`

I can instead use a polyfill, but just in case you wanted a safer version here :)